### PR TITLE
fix: No version for golangci-lint

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -69,7 +69,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.8
           args: --verbose
 
   unittests:


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We have pinned a version for golangci-lint
- Linting breaks because ti is too old

## What is the new behavior?

- No pinned version
- Linting automatically uses a new release once available

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
