### PR TITLE
fix: use Go 1.25 in release workflow

### DIFF
--- a/.github/workflows/build-and-release-binaries.yml
+++ b/.github/workflows/build-and-release-binaries.yml
@@ -4,6 +4,9 @@ on:
     types:
       - published
 
+env:
+  GOLANG_VERSION: '1.25.x'
+  
 jobs:
   binaries:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
        
       - name: Download cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@v2

--- a/.github/workflows/build-and-release-binaries.yml
+++ b/.github/workflows/build-and-release-binaries.yml
@@ -5,7 +5,7 @@ on:
       - published
 
 env:
-  GOLANG_VERSION: '1.25.x'
+  GOLANG_VERSION: '1.26'
   
 jobs:
   binaries:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pgvillage-tools/chainsmith
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/goccy/go-yaml v1.19.2


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the new behavior?
use Go 1.25 in release workflow

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the Go toolchain version across the project and CI, upgrading to Go 1.26.
  * CI configuration now references a centralized Go version variable to keep build/runtime versions consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->